### PR TITLE
Allow setting prefix inside container

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -274,6 +274,7 @@ server {
 	{{ range $container := $containers }}
 	{{/* Determine whether this container has specified a virtual path, or default to the / pattern */}}
 	{{ $location := coalesce $container.Env.VIRTUAL_PATH "/" }}
+	{{ $prefix := coalesce $container.Env.VIRTUAL_PREFIX "" }}
 	{{ $is_regexp := hasPrefix "^" $location }}
 	{{ $modifier := when $is_regexp "~" "" }}
 
@@ -286,7 +287,7 @@ server {
 		include fastcgi.conf;
 		fastcgi_pass {{ trim $container.Name }};
 		{{ else }}
-		proxy_pass {{ trim $proto }}://{{ trim $container.Name }};
+		proxy_pass {{ trim $proto }}://{{ trim $container.Name }}{{ $prefix }};
 		{{ end }}
 
 		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
@@ -328,6 +329,7 @@ server {
 	{{ range $container := $containers }}
 	{{/* Determine whether this container has specified a virtual path, or default to the / pattern */}}
 	{{ $location := coalesce $container.Env.VIRTUAL_PATH "/" }}
+	{{ $prefix := coalesce $container.Env.VIRTUAL_PREFIX "" }}
 
 	{{ $is_regexp := hasPrefix "^" $location }}
 	{{ $modifier := when $is_regexp "~" "" }}
@@ -341,7 +343,7 @@ server {
 		include fastcgi.conf;
 		fastcgi_pass {{ trim $container.Name }};
 		{{ else }}
-		proxy_pass {{ trim $proto }}://{{ trim $container.Name }};
+		proxy_pass {{ trim $proto }}://{{ trim $container.Name }}{{ $prefix }};
 		{{ end }}
 		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
 		auth_basic	"Restricted {{ $host }}";


### PR DESCRIPTION
Additionally allow for `VIRTUAL_PREFIX` environment variable to add prefix to the proxy-targe url. Useful for example if the target container expects the base to be `/` (eg. official grafana image).